### PR TITLE
refactor: return an `AsyncGenerator` instead

### DIFF
--- a/__tests__/fdir.test.ts
+++ b/__tests__/fdir.test.ts
@@ -497,12 +497,12 @@ test(`do not convert \\\\ to \\`, async (t) => {
 
 test("interrupted iterator should stop yielding results", async (t) => {
   const api = new fdir().crawl("./src");
-  const iterator = api.withIterator()[Symbol.asyncIterator]();
-  const results: string[] = [];
+  const iterator = api.withIterator();
+  const results: (string | void)[] = [];
   let next = await iterator.next();
   do {
     results.push(next.value);
-    iterator.return?.();
+    iterator.return();
   } while (next.done !== false);
   t.expect(results.length).toBe(1);
 });

--- a/src/api/iterator.ts
+++ b/src/api/iterator.ts
@@ -1,4 +1,4 @@
-import { Options, IterableOutput } from "../types";
+import { Options, IterableOutput, OutputIterator } from "../types";
 import { Walker } from "./walker";
 
 class WalkerIterator<TOutput extends IterableOutput> {
@@ -48,7 +48,7 @@ class WalkerIterator<TOutput extends IterableOutput> {
     }
   };
 
-  async *[Symbol.asyncIterator]() {
+  async *start(): OutputIterator<TOutput> {
     this.#walker.start();
 
     try {
@@ -85,6 +85,6 @@ export function iterator<TOutput extends IterableOutput>(
   root: string,
   options: Options
 ): AsyncIterable<TOutput[number]> {
-  const iterator = new WalkerIterator<TOutput>(root, options);
-  return iterator;
+  const walker = new WalkerIterator<TOutput>(root, options);
+  return walker.start();
 }

--- a/src/builder/api-builder.ts
+++ b/src/builder/api-builder.ts
@@ -1,7 +1,13 @@
 import { callback, promise } from "../api/async";
 import { sync } from "../api/sync";
 import { iterator } from "../api/iterator";
-import { Options, Output, ResultCallback, IterableOutput } from "../types";
+import {
+  Options,
+  Output,
+  ResultCallback,
+  IterableOutput,
+  OutputIterator,
+} from "../types";
 
 export class APIBuilder<TReturnType extends Output> {
   constructor(
@@ -22,7 +28,7 @@ export class APIBuilder<TReturnType extends Output> {
   }
 
   withIterator(): TReturnType extends IterableOutput
-    ? AsyncIterable<TReturnType[number]>
+    ? OutputIterator<TReturnType>
     : never {
     // TODO (43081j): get rid of this awful `never`
     return iterator(this.root, this.options) as never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,11 @@ export type PathsOutput = string[];
 
 export type Output = OnlyCountsOutput | PathsOutput | GroupOutput;
 export type IterableOutput = PathsOutput | GroupOutput;
+export type OutputIterator<T extends IterableOutput> = AsyncGenerator<
+  T[number],
+  void,
+  void
+>;
 
 export type FSLike = {
   readdir: typeof nativeFs.readdir;


### PR DESCRIPTION
returns an actual iterator instead of some class you can iterate over. this allows you to do something like `await withIterator().next()`, and in the future will allow you to use async iterator helpers with no need of any code changes on the fdir side, like `withIterator().take(2)`.

originally used `AsyncIteratorObject`, replaced with `AsyncGenerator` so that the `.return` and `.throw` methods are well defined, `AsyncGenerator` extends `AsyncIteratorObject` on new ts versions anyways. this also avoids requiring ts >=5.6 like it almost did. the text below is now obsolete:

~~this is done by using the new `AsyncIteratorObject` type from ts 5.6 https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#iterator-helper-methods. it currently is identical to `AsyncIterator` but will have support for async iterator helpers~~